### PR TITLE
Fe/dashboard

### DIFF
--- a/frontend/mocking/courses.ts
+++ b/frontend/mocking/courses.ts
@@ -1,10 +1,21 @@
 import { Course } from "@interfaces/course";
 import { faker } from "@faker-js/faker";
 
+export const categories = [
+  "Category 1",
+  "Category 2",
+  "Category 3",
+  "Category 4",
+  "Category 5",
+  "Category 6",
+];
+
 export function generateCourses(count: number = 5): Course[] {
   const courses: Course[] = [];
   for (let i = 0; i < count; i++) {
-    const randomImageNumber = faker.datatype.number({ min: 1, max: 1000 });
+    const randomImageNumber = faker.number.int({ min: 1, max: 1000 });
+    const randomCategory =
+      categories[faker.number.int({ min: 0, max: categories.length - 1 })];
     courses.push({
       id: faker.string.uuid(),
       title: faker.lorem.words(3),
@@ -12,6 +23,7 @@ export function generateCourses(count: number = 5): Course[] {
       photo: `https://placedog.net/${randomImageNumber}`,
       progress: faker.number.int({ min: 0, max: 100 }),
       subtitle: faker.lorem.words(3),
+      category: randomCategory,
     });
   }
   return courses;

--- a/frontend/mocking/courses.ts
+++ b/frontend/mocking/courses.ts
@@ -1,4 +1,4 @@
-import { Course } from "@interfaces/course";
+import { Chapter, Course, Module } from "@interfaces/course";
 import { faker } from "@faker-js/faker";
 
 export const categories = [
@@ -16,6 +16,26 @@ export function generateCourses(count: number = 5): Course[] {
     const randomImageNumber = faker.number.int({ min: 1, max: 1000 });
     const randomCategory =
       categories[faker.number.int({ min: 0, max: categories.length - 1 })];
+
+    const sections: Chapter[] = [];
+    const sectionCount = faker.number.int({ min: 1, max: 5 });
+    for (let j = 0; j < sectionCount; j++) {
+      const checklists: Module[] = [];
+      const checklistCount = faker.number.int({ min: 1, max: 10 });
+      for (let k = 0; k < checklistCount; k++) {
+        checklists.push({
+          id: faker.string.uuid(),
+          title: faker.lorem.words(2),
+          completed: faker.datatype.boolean(),
+        });
+      }
+      sections.push({
+        id: faker.string.uuid(),
+        title: faker.lorem.words(3),
+        checklists: checklists,
+      });
+    }
+
     courses.push({
       id: faker.string.uuid(),
       title: faker.lorem.words(3),
@@ -24,6 +44,7 @@ export function generateCourses(count: number = 5): Course[] {
       progress: faker.number.int({ min: 0, max: 100 }),
       subtitle: faker.lorem.words(3),
       category: randomCategory,
+      sections: sections,
     });
   }
   return courses;

--- a/frontend/mocking/dashboard.ts
+++ b/frontend/mocking/dashboard.ts
@@ -1,0 +1,18 @@
+import { Course } from "@interfaces/course";
+import { faker } from "@faker-js/faker";
+
+export function generateCourses(count: number = 5): Course[] {
+  const courses: Course[] = [];
+  for (let i = 0; i < count; i++) {
+    const randomImageNumber = faker.datatype.number({ min: 1, max: 1000 });
+    courses.push({
+      id: faker.string.uuid(),
+      title: faker.lorem.words(3),
+      description: faker.lorem.sentences(2),
+      photo: `https://placedog.net/${randomImageNumber}`,
+      progress: faker.number.int({ min: 0, max: 100 }),
+      subtitle: faker.lorem.words(3),
+    });
+  }
+  return courses;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-slot": "^1.0.2",
     "@tanstack/react-router": "^1.35.6",
@@ -24,6 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",
+    "swiper": "^11.1.4",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "vitest": "^1.6.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.1.2",
+    "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-slot": "^1.0.2",
     "@tanstack/react-router": "^1.35.6",

--- a/frontend/src/components/CourseCards.tsx
+++ b/frontend/src/components/CourseCards.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@/components/ui/card';
 import { Course } from '@interfaces/course';
+import { Link } from '@tanstack/react-router';
 
 interface CourseCardsProps {
   courses: Course[];
@@ -7,32 +8,35 @@ interface CourseCardsProps {
 }
 
 export const CourseCards: React.FC<CourseCardsProps> = ({ courses, showProgress }) => {
+  console.log(courses)
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
       { courses.map((course) => (
-        <Card key={ course.id } className="p-6 rounded-lg shadow-lg">
-          <img
-            src={ course.photo }
-            alt="Card Image"
-            width={ 600 }
-            height={ 400 }
-            className="w-full h-48 object-cover rounded-t-lg"
-          />
-          <div className="mt-4">
-            <h3 className="text-xl font-bold">{ course.title }</h3>
-            <p className="text-gray-500 mt-2">{ course.subtitle }</p>
+        <Link key={ course.id } to={ `/course/${course.id}` }>
+          <Card key={ course.id } className="p-6 rounded-lg shadow-lg">
+            <img
+              src={ course.photo }
+              alt="Card Image"
+              width={ 600 }
+              height={ 400 }
+              className="w-full h-48 object-cover rounded-t-lg"
+            />
             <div className="mt-4">
-              <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
-                { showProgress && (
-                  <div
-                    className="bg-blue-600 h-2.5 rounded-full"
-                    style={ { width: `${course.progress}%` } }
-                  />
-                ) }
+              <h3 className="text-xl font-bold">{ course.title }</h3>
+              <p className="text-gray-500 mt-2">{ course.subtitle }</p>
+              <div className="mt-4">
+                <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+                  { showProgress && (
+                    <div
+                      className="bg-blue-600 h-2.5 rounded-full"
+                      style={ { width: `${course.progress}%` } }
+                    />
+                  ) }
+                </div>
               </div>
             </div>
-          </div>
-        </Card>
+          </Card>
+        </Link>
       )) }
     </div>
   );

--- a/frontend/src/components/CourseCards.tsx
+++ b/frontend/src/components/CourseCards.tsx
@@ -1,0 +1,39 @@
+import { Card } from '@/components/ui/card';
+import { Course } from '@interfaces/course';
+
+interface CourseCardsProps {
+  courses: Course[];
+  showProgress?: boolean;
+}
+
+export const CourseCards: React.FC<CourseCardsProps> = ({ courses, showProgress }) => {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      { courses.map((course) => (
+        <Card key={ course.id } className="p-6 rounded-lg shadow-lg">
+          <img
+            src={ course.photo }
+            alt="Card Image"
+            width={ 600 }
+            height={ 400 }
+            className="w-full h-48 object-cover rounded-t-lg"
+          />
+          <div className="mt-4">
+            <h3 className="text-xl font-bold">{ course.title }</h3>
+            <p className="text-gray-500 mt-2">{ course.subtitle }</p>
+            <div className="mt-4">
+              <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+                { showProgress && (
+                  <div
+                    className="bg-blue-600 h-2.5 rounded-full"
+                    style={ { width: `${course.progress}%` } }
+                  />
+                ) }
+              </div>
+            </div>
+          </div>
+        </Card>
+      )) }
+    </div>
+  );
+};

--- a/frontend/src/components/GalleryCards.tsx
+++ b/frontend/src/components/GalleryCards.tsx
@@ -1,0 +1,41 @@
+import { Course } from '@interfaces/course';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Pagination } from 'swiper/modules';
+import { Card } from './ui/card';
+
+interface GalleryCardsProps {
+  galleryItems: Partial<Course>[];
+}
+
+export const GalleryCards: React.FC<GalleryCardsProps> = ({ galleryItems }) => {
+  return (
+
+    <Swiper
+      modules={ [Navigation, Pagination] }
+      spaceBetween={ 10 }
+      slidesPerView={ 5 }
+      navigation
+      pagination={ { clickable: true } }
+      className="w-full"
+    >
+      { galleryItems.map((item) => (
+        <SwiperSlide key={ item.id } className="flex justify-center">
+          <Card className="p-4 rounded-lg shadow-lg">
+            <img
+              src={ item.photo }
+              alt="Gallery Image"
+              className="w-full h-32 object-cover rounded-t-lg"
+            />
+            <div className="mt-4">
+              <h4 className="text-lg font-bold">{ item.title }</h4>
+              <p className="text-gray-500 mt-1">{ item.subtitle }</p>
+            </div>
+          </Card>
+        </SwiperSlide>
+      )) }
+    </Swiper>
+  );
+};

--- a/frontend/src/components/GalleryCards.tsx
+++ b/frontend/src/components/GalleryCards.tsx
@@ -5,6 +5,7 @@ import 'swiper/css/pagination';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Navigation, Pagination } from 'swiper/modules';
 import { Card } from './ui/card';
+import { Link } from '@tanstack/react-router';
 
 interface GalleryCardsProps {
   galleryItems: Partial<Course>[];
@@ -23,17 +24,19 @@ export const GalleryCards: React.FC<GalleryCardsProps> = ({ galleryItems }) => {
     >
       { galleryItems.map((item) => (
         <SwiperSlide key={ item.id } className="flex justify-center">
-          <Card className="p-4 rounded-lg shadow-lg">
-            <img
-              src={ item.photo }
-              alt="Gallery Image"
-              className="w-full h-32 object-cover rounded-t-lg"
-            />
-            <div className="mt-4">
-              <h4 className="text-lg font-bold">{ item.title }</h4>
-              <p className="text-gray-500 mt-1">{ item.subtitle }</p>
-            </div>
-          </Card>
+          <Link to={ `/course/${item.id}` }>
+            <Card className="p-4 rounded-lg shadow-lg">
+              <img
+                src={ item.photo }
+                alt="Gallery Image"
+                className="w-full h-32 object-cover rounded-t-lg"
+              />
+              <div className="mt-4">
+                <h4 className="text-lg font-bold">{ item.title }</h4>
+                <p className="text-gray-500 mt-1">{ item.subtitle }</p>
+              </div>
+            </Card>
+          </Link>
         </SwiperSlide>
       )) }
     </Swiper>

--- a/frontend/src/components/ui/accordion.tsx
+++ b/frontend/src/components/ui/accordion.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { ChevronDown } from "lucide-react"
+
+import { cn } from "src/lib/utils"
+
+const Accordion = AccordionPrimitive.Root
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+))
+AccordionItem.displayName = "AccordionItem"
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+))
+
+AccordionContent.displayName = AccordionPrimitive.Content.displayName
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "src/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { Check } from "lucide-react"
+
+import { cn } from "src/lib/utils"
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+))
+Checkbox.displayName = CheckboxPrimitive.Root.displayName
+
+export { Checkbox }

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "src/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,4 @@
+
 @tailwind base;
   @tailwind components;
   @tailwind utilities;
@@ -74,3 +75,7 @@
       @apply bg-background text-foreground;
     }
   }
+
+    .swiper-pagination-bullets {
+      display: none;
+    }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,7 @@
+import { RouterProvider } from '@tanstack/react-router';
 import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
-import SuperTokens from 'supertokens-web-js';
-import App from './App';
 import './index.css';
-import { RouterProvider } from '@tanstack/react-router';
 import router from './providers/router-provider';
 
 
@@ -13,7 +11,6 @@ if (!rootElement.innerHTML) {
 
   root.render(
     <StrictMode>
-      {/* <App /> */ }
       <RouterProvider router={ router } />
     </StrictMode>
   );

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -13,13 +13,14 @@
 import { Route as rootRoute } from './routes/__root'
 import { Route as AuthImport } from './routes/auth'
 import { Route as DashboardLayoutImport } from './routes/_dashboardLayout'
+import { Route as CourseLayoutImport } from './routes/_courseLayout'
 import { Route as IndexImport } from './routes/index'
 import { Route as DashboardLayoutDashboardIndexImport } from './routes/_dashboardLayout/dashboard/index'
 import { Route as DashboardLayoutCoursesIndexImport } from './routes/_dashboardLayout/courses/index'
 import { Route as DashboardLayoutUserSettingsImport } from './routes/_dashboardLayout/_user/settings'
 import { Route as DashboardLayoutUserProfileImport } from './routes/_dashboardLayout/_user/profile'
-import { Route as DashboardLayoutCourseCreateIndexImport } from './routes/_dashboardLayout/course/create/index'
-import { Route as DashboardLayoutCourseCourseIDIndexImport } from './routes/_dashboardLayout/course/$courseID/index'
+import { Route as CourseLayoutCourseCourseIDImport } from './routes/_courseLayout/course/$courseID'
+import { Route as CourseLayoutCourseCreateIndexImport } from './routes/_courseLayout/course/create/index'
 
 // Create/Update Routes
 
@@ -30,6 +31,11 @@ const AuthRoute = AuthImport.update({
 
 const DashboardLayoutRoute = DashboardLayoutImport.update({
   id: '/_dashboardLayout',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const CourseLayoutRoute = CourseLayoutImport.update({
+  id: '/_courseLayout',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -63,16 +69,17 @@ const DashboardLayoutUserProfileRoute = DashboardLayoutUserProfileImport.update(
   } as any,
 )
 
-const DashboardLayoutCourseCreateIndexRoute =
-  DashboardLayoutCourseCreateIndexImport.update({
-    path: '/course/create/',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
+const CourseLayoutCourseCourseIDRoute = CourseLayoutCourseCourseIDImport.update(
+  {
+    path: '/course/$courseID',
+    getParentRoute: () => CourseLayoutRoute,
+  } as any,
+)
 
-const DashboardLayoutCourseCourseIDIndexRoute =
-  DashboardLayoutCourseCourseIDIndexImport.update({
-    path: '/course/$courseID/',
-    getParentRoute: () => DashboardLayoutRoute,
+const CourseLayoutCourseCreateIndexRoute =
+  CourseLayoutCourseCreateIndexImport.update({
+    path: '/course/create/',
+    getParentRoute: () => CourseLayoutRoute,
   } as any)
 
 // Populate the FileRoutesByPath interface
@@ -84,6 +91,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/_courseLayout': {
+      id: '/_courseLayout'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof CourseLayoutImport
       parentRoute: typeof rootRoute
     }
     '/_dashboardLayout': {
@@ -99,6 +113,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/auth'
       preLoaderRoute: typeof AuthImport
       parentRoute: typeof rootRoute
+    }
+    '/_courseLayout/course/$courseID': {
+      id: '/_courseLayout/course/$courseID'
+      path: '/course/$courseID'
+      fullPath: '/course/$courseID'
+      preLoaderRoute: typeof CourseLayoutCourseCourseIDImport
+      parentRoute: typeof CourseLayoutImport
     }
     '/_dashboardLayout/_user/profile': {
       id: '/_dashboardLayout/_user/profile'
@@ -128,19 +149,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardLayoutDashboardIndexImport
       parentRoute: typeof DashboardLayoutImport
     }
-    '/_dashboardLayout/course/$courseID/': {
-      id: '/_dashboardLayout/course/$courseID/'
-      path: '/course/$courseID'
-      fullPath: '/course/$courseID'
-      preLoaderRoute: typeof DashboardLayoutCourseCourseIDIndexImport
-      parentRoute: typeof DashboardLayoutImport
-    }
-    '/_dashboardLayout/course/create/': {
-      id: '/_dashboardLayout/course/create/'
+    '/_courseLayout/course/create/': {
+      id: '/_courseLayout/course/create/'
       path: '/course/create'
       fullPath: '/course/create'
-      preLoaderRoute: typeof DashboardLayoutCourseCreateIndexImport
-      parentRoute: typeof DashboardLayoutImport
+      preLoaderRoute: typeof CourseLayoutCourseCreateIndexImport
+      parentRoute: typeof CourseLayoutImport
     }
   }
 }
@@ -149,13 +163,15 @@ declare module '@tanstack/react-router' {
 
 export const routeTree = rootRoute.addChildren({
   IndexRoute,
+  CourseLayoutRoute: CourseLayoutRoute.addChildren({
+    CourseLayoutCourseCourseIDRoute,
+    CourseLayoutCourseCreateIndexRoute,
+  }),
   DashboardLayoutRoute: DashboardLayoutRoute.addChildren({
     DashboardLayoutUserProfileRoute,
     DashboardLayoutUserSettingsRoute,
     DashboardLayoutCoursesIndexRoute,
     DashboardLayoutDashboardIndexRoute,
-    DashboardLayoutCourseCourseIDIndexRoute,
-    DashboardLayoutCourseCreateIndexRoute,
   }),
   AuthRoute,
 })
@@ -169,6 +185,7 @@ export const routeTree = rootRoute.addChildren({
       "filePath": "__root.tsx",
       "children": [
         "/",
+        "/_courseLayout",
         "/_dashboardLayout",
         "/auth"
       ]
@@ -176,19 +193,28 @@ export const routeTree = rootRoute.addChildren({
     "/": {
       "filePath": "index.tsx"
     },
+    "/_courseLayout": {
+      "filePath": "_courseLayout.tsx",
+      "children": [
+        "/_courseLayout/course/$courseID",
+        "/_courseLayout/course/create/"
+      ]
+    },
     "/_dashboardLayout": {
       "filePath": "_dashboardLayout.tsx",
       "children": [
         "/_dashboardLayout/_user/profile",
         "/_dashboardLayout/_user/settings",
         "/_dashboardLayout/courses/",
-        "/_dashboardLayout/dashboard/",
-        "/_dashboardLayout/course/$courseID/",
-        "/_dashboardLayout/course/create/"
+        "/_dashboardLayout/dashboard/"
       ]
     },
     "/auth": {
       "filePath": "auth.tsx"
+    },
+    "/_courseLayout/course/$courseID": {
+      "filePath": "_courseLayout/course/$courseID.tsx",
+      "parent": "/_courseLayout"
     },
     "/_dashboardLayout/_user/profile": {
       "filePath": "_dashboardLayout/_user/profile.tsx",
@@ -206,13 +232,9 @@ export const routeTree = rootRoute.addChildren({
       "filePath": "_dashboardLayout/dashboard/index.tsx",
       "parent": "/_dashboardLayout"
     },
-    "/_dashboardLayout/course/$courseID/": {
-      "filePath": "_dashboardLayout/course/$courseID/index.tsx",
-      "parent": "/_dashboardLayout"
-    },
-    "/_dashboardLayout/course/create/": {
-      "filePath": "_dashboardLayout/course/create/index.tsx",
-      "parent": "/_dashboardLayout"
+    "/_courseLayout/course/create/": {
+      "filePath": "_courseLayout/course/create/index.tsx",
+      "parent": "/_courseLayout"
     }
   }
 }

--- a/frontend/src/routes/_courseLayout.tsx
+++ b/frontend/src/routes/_courseLayout.tsx
@@ -1,0 +1,38 @@
+import UserNav from '@/components/UserNav';
+import { createFileRoute, Link, Outlet } from '@tanstack/react-router';
+import { FaBell, FaStar } from 'react-icons/fa';
+import strapiLogo from '../assets/strapi-logo.svg';
+
+export const Route = createFileRoute('/_courseLayout')({
+
+  component: () => <CourseLayout />,
+});
+
+export const CourseLayout = () => {
+  return (
+    <div>
+      <div className="p-2 flex justify-between items-center m-2">
+        <div className="flex gap-2 items-center">
+          <Link to="/dashboard" className='w-8 h-8 mr-2'>
+            <img
+              src={ strapiLogo }
+              alt="Logo"
+            />
+          </Link>
+        </div>
+        <h2 className="text-xl font-bold w-full">Course Name</h2>
+        <div className="flex items-center gap-4 w-full justify-end">
+          <div className="flex">
+            <FaStar className='w-6 h-6 mr-2' />Leave a rating
+          </div>
+          <FaBell className='w-6 h-6' />
+          <UserNav />
+        </div>
+      </div>
+      <hr />
+      <main className="p-2">
+        <Outlet />
+      </main>
+    </div>
+  );
+};

--- a/frontend/src/routes/_courseLayout/course/$courseID.tsx
+++ b/frontend/src/routes/_courseLayout/course/$courseID.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute('/_dashboardLayout/course/$courseID/')({
+export const Route = createFileRoute('/_courseLayout/course/$courseID')({
   // In a loader
-  loader: ({ params }) => params.courseId,
+  loader: ({ params }) => params.courseID,
   component: PostComponent,
 })
 

--- a/frontend/src/routes/_courseLayout/course/$courseID.tsx
+++ b/frontend/src/routes/_courseLayout/course/$courseID.tsx
@@ -1,12 +1,79 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Course } from '@interfaces/course'
+import { generateCourses } from '@mock/courses'
 import { createFileRoute } from '@tanstack/react-router'
+import { PlayIcon } from 'lucide-react'
 
 export const Route = createFileRoute('/_courseLayout/course/$courseID')({
-  // In a loader
-  loader: ({ params }) => params.courseID,
-  component: PostComponent,
+  loader: ({ params }) => {
+    const courses = generateCourses(1);
+    const course = courses[0]; // Get the first (and only) course
+    return { course, courseID: params.courseID }
+  },
+  component: SingleCourse,
 })
 
-function PostComponent() {
-  const { courseID } = Route.useParams()
-  return <div>Post ID: { courseID }</div>
+export default function SingleCourse() {
+  const { course, courseID } = Route.useLoaderData<{ course: Course, courseID: string }>();
+  console.log(course);
+
+  if (!course) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="flex h-screen w-full">
+      <div className="flex-1 overflow-hidden rounded-r-lg bg-gray-100 dark:bg-gray-900 h-[70%]">
+        <div className="relative h-full w-full">
+          <div className="absolute inset-0 overflow-hidden">
+            <video className="h-full w-full object-cover">
+              <source
+                src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4"
+                type="video/mp4"
+              />
+            </video>
+            <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+          </div>
+          <div className="relative z-10 flex h-full items-center justify-center">
+            <Button
+              variant="ghost"
+              size="lg"
+              className="rounded-full bg-white/20 p-4 text-white hover:bg-white/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75"
+            >
+              <PlayIcon className="h-8 w-8" />
+            </Button>
+          </div>
+          <div className="absolute bottom-0 left-0 right-0 bg-black/50 backdrop-blur-sm p-4 text-white">
+            <h3 className="text-lg font-bold">{ course.title }</h3>
+            <p className="text-sm">
+              { course.description }
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="flex w-[20%] flex-col overflow-hidden rounded-l-lg bg-white p-6 dark:bg-gray-950">
+        <Accordion type="single" collapsible className="flex-1">
+          { course.sections.map((section, index) => (
+            <AccordionItem key={ section.id } value={ `item-${index + 1}` }>
+              <AccordionTrigger className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold">{ section.title }</h3>
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="space-y-2">
+                  { section.checklists.map((checklist) => (
+                    <div key={ checklist.id } className="flex items-center gap-2">
+                      <Checkbox checked={ checklist.completed } />
+                      <span>{ checklist.title }</span>
+                    </div>
+                  )) }
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          )) }
+        </Accordion>
+      </div>
+    </div>
+  )
 }

--- a/frontend/src/routes/_courseLayout/course/create/index.tsx
+++ b/frontend/src/routes/_courseLayout/course/create/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute('/_dashboardLayout/course/create/')({
+export const Route = createFileRoute('/_courseLayout/course/create/')({
   component: () => <div>Hello /_dashboardLayout/course/create/!</div>
 })

--- a/frontend/src/routes/_dashboardLayout.tsx
+++ b/frontend/src/routes/_dashboardLayout.tsx
@@ -2,6 +2,7 @@ import UserNav from '@/components/UserNav';
 import { createFileRoute, Link, Outlet } from '@tanstack/react-router';
 import { FaBell } from 'react-icons/fa';
 import strapiLogo from '../assets/strapi-logo.svg'
+import { Input } from '@/components/ui/input';
 
 export const Route = createFileRoute('/_dashboardLayout')({
   component: () => <DashboardLayout />,
@@ -28,11 +29,9 @@ export const DashboardLayout = () => {
           <Link to="/courses" className="[&.active]:font-bold">
             Courses
           </Link>
-          <Link to="/course/123" className="[&.active]:font-bold">
-            Course
-          </Link>
         </div>
         <div className="flex gap-2 items-center">
+          <Input placeholder="Search..." />
           <FaBell className='w-6 h-6' />
           <UserNav />
         </div>

--- a/frontend/src/routes/_dashboardLayout.tsx
+++ b/frontend/src/routes/_dashboardLayout.tsx
@@ -3,23 +3,22 @@ import UserNav from '@/components/UserNav';
 import { createFileRoute, Link, Outlet } from '@tanstack/react-router';
 import { FaBell, FaSearch } from 'react-icons/fa';
 import strapiLogo from '../assets/strapi-logo.svg';
-
 export const Route = createFileRoute('/_dashboardLayout')({
   component: () => <DashboardLayout />,
 });
 
 export const DashboardLayout = () => {
+
   return (
     <div>
       <div className="p-2 flex justify-between items-center m-2">
         <div className="flex gap-2 items-center">
-          <img
-            src={ strapiLogo }
-            width={ 128 }
-            height={ 128 }
-            alt="Logo"
-            className="h-8 w-8"
-          />
+          <Link to="/dashboard" className='w-8 h-8 mr-2'>
+            <img
+              src={ strapiLogo }
+              alt="Logo"
+            />
+          </Link>
           <Link to="/auth" className="[&.active]:font-bold">
             Auth
           </Link>{ ' ' }
@@ -30,6 +29,7 @@ export const DashboardLayout = () => {
             Courses
           </Link>
         </div>
+        { }
         <div className="flex items-center gap-4 w-full justify-end">
           <div className="relative w-1/3">
             <FaSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500 z-10" />

--- a/frontend/src/routes/_dashboardLayout.tsx
+++ b/frontend/src/routes/_dashboardLayout.tsx
@@ -1,8 +1,8 @@
+import { Input } from '@/components/ui/input';
 import UserNav from '@/components/UserNav';
 import { createFileRoute, Link, Outlet } from '@tanstack/react-router';
-import { FaBell } from 'react-icons/fa';
-import strapiLogo from '../assets/strapi-logo.svg'
-import { Input } from '@/components/ui/input';
+import { FaBell, FaSearch } from 'react-icons/fa';
+import strapiLogo from '../assets/strapi-logo.svg';
 
 export const Route = createFileRoute('/_dashboardLayout')({
   component: () => <DashboardLayout />,
@@ -30,8 +30,16 @@ export const DashboardLayout = () => {
             Courses
           </Link>
         </div>
-        <div className="flex gap-2 items-center">
-          <Input placeholder="Search..." />
+        <div className="flex items-center gap-4 w-full justify-end">
+          <div className="relative w-1/3">
+            <FaSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-500 z-10" />
+            <Input
+              type="text"
+              placeholder="Search"
+              className="pl-10 pr-3 py-2 text-md w-full border border-gray-300 rounded shadow-sm focus:outline-none focus:ring-2 focus:ring-[#6E23DD] focus:border-transparent"
+              value=""
+            />
+          </div>
           <FaBell className='w-6 h-6' />
           <UserNav />
         </div>

--- a/frontend/src/routes/_dashboardLayout/courses/index.tsx
+++ b/frontend/src/routes/_dashboardLayout/courses/index.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
 import { CourseCards } from '@/components/CourseCards';
 import { categories, generateCourses } from '@mock/courses';
 import { createFileRoute } from '@tanstack/react-router';
+import { useState } from 'react';
 
 export const Route = createFileRoute('/_dashboardLayout/courses/')({
   component: () => <CoursesPage />,

--- a/frontend/src/routes/_dashboardLayout/courses/index.tsx
+++ b/frontend/src/routes/_dashboardLayout/courses/index.tsx
@@ -1,5 +1,16 @@
+import { CourseCards } from '@/components/CourseCards';
+import { generateCourses } from '@mock/dashboard';
 import { createFileRoute } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/_dashboardLayout/courses/')({
-  component: () => <div>Hello /_dashboard/courses/!</div>
+  component: () => <CoursesPage />,
 })
+
+function CoursesPage() {
+  const courses = generateCourses(20);
+  return (
+    <div>
+      <CourseCards courses={ courses } showProgress={ false } />;
+    </div>
+  )
+}

--- a/frontend/src/routes/_dashboardLayout/courses/index.tsx
+++ b/frontend/src/routes/_dashboardLayout/courses/index.tsx
@@ -1,16 +1,51 @@
+import React, { useState } from 'react';
 import { CourseCards } from '@/components/CourseCards';
-import { generateCourses } from '@mock/dashboard';
-import { createFileRoute } from '@tanstack/react-router'
+import { categories, generateCourses } from '@mock/courses';
+import { createFileRoute } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/_dashboardLayout/courses/')({
   component: () => <CoursesPage />,
-})
+});
 
 function CoursesPage() {
   const courses = generateCourses(20);
+
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  const filteredCourses = selectedCategory
+    ? courses.filter(course => course.category === selectedCategory)
+    : courses;
+
   return (
-    <div>
-      <CourseCards courses={ courses } showProgress={ false } />;
+    <div className="grid grid-cols-1 md:grid-cols-5 gap-4 p-4">
+      {/* Categories List */ }
+      <div className="order-1 md:order-2 md:col-span-1 bg-gray-100 p-6 rounded-lg shadow-md space-y-4">
+        <h2 className="text-xl font-bold mb-4">Categories</h2>
+        <ul className="space-y-4">
+          <li>
+            <button
+              onClick={ () => setSelectedCategory(null) }
+              className={ `w-full text-left p-2 rounded-lg ${selectedCategory === null ? 'bg-blue-500 text-white' : 'bg-white text-black'}` }
+            >
+              Show All
+            </button>
+          </li>
+          { categories.map(category => (
+            <li key={ category }>
+              <button
+                onClick={ () => setSelectedCategory(category) }
+                className={ `w-full text-left p-2 rounded-lg ${selectedCategory === category ? 'bg-blue-500 text-white' : 'bg-white text-black'}` }
+              >
+                { category }
+              </button>
+            </li>
+          )) }
+        </ul>
+      </div>
+      {/* CourseCards */ }
+      <div className="order-2 md:order-1 md:col-span-4">
+        <CourseCards courses={ filteredCourses } showProgress={ false } />
+      </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/routes/_dashboardLayout/dashboard/index.tsx
+++ b/frontend/src/routes/_dashboardLayout/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import { CourseCards } from '@/components/CourseCards';
 import { GalleryCards } from '@/components/GalleryCards';
-import { generateCourses } from '@mock/dashboard';
+import { generateCourses } from '@mock/courses';
 import { createFileRoute } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/_dashboardLayout/dashboard/')({

--- a/frontend/src/routes/_dashboardLayout/dashboard/index.tsx
+++ b/frontend/src/routes/_dashboardLayout/dashboard/index.tsx
@@ -1,5 +1,24 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { CourseCards } from '@/components/CourseCards';
+import { GalleryCards } from '@/components/GalleryCards';
+import { generateCourses } from '@mock/dashboard';
+import { createFileRoute } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/_dashboardLayout/dashboard/')({
-  component: () => <div>Hello /dashboard/!</div>
-})
+  component: () => <Dashboard />,
+});
+
+function Dashboard() {
+  const courses = generateCourses(20);
+  return (
+    <div className="space-y-16 p-4 md:p-8">
+      <div className="space-y-8">
+        <h2 className="text-center font-bold text-4xl mb-6">Courses in Progress</h2>
+        <CourseCards courses={ courses.slice(0, 3) } showProgress />
+      </div>
+      <div className="space-y-8">
+        <h2 className="text-center font-bold text-4xl mb-6">New Courses</h2>
+        <GalleryCards galleryItems={ courses } />
+      </div>
+    </div>
+  );
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,13 +1,14 @@
-import type { Config } from "tailwindcss"
+import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 const config = {
   darkMode: ["class"],
   content: [
-    './pages/**/*.{ts,tsx}',
-    './components/**/*.{ts,tsx}',
-    './app/**/*.{ts,tsx}',
-    './src/**/*.{ts,tsx}',
-	],
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
+  ],
   prefix: "",
   theme: {
     container: {
@@ -74,7 +75,7 @@ const config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
-} satisfies Config
+  plugins: [animate],
+} satisfies Config;
 
-export default config
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,27 +5,23 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-  "baseUrl": ".",
-   "paths": {
-     "@/*": [
-       "./src/*"
-     ]
-   },
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@interfaces/*": ["./types/*"],
+      "@mock/*": ["./mocking/*"]
+    }
   },
-  "include": ["src"],
+  "include": ["src", "types", "mocking"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,13 +10,14 @@ import { TanStackRouterVite } from "@tanstack/router-vite-plugin";
 export default defineConfig({
   plugins: [react(), TanStackRouterVite(), tsconfigPaths()],
   test: {
-    // allows you to use stuff like describe, it, vi without importing
     globals: true,
     include: ["./tests/*.test.ts"],
   },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "@interfaces": path.resolve(__dirname, "./types"),
+      "@mock": path.resolve(__dirname, "./mocking"),
     },
   },
 });


### PR DESCRIPTION
- Dashboard has now a layout, takes top 3 for now
- Bottom is a gallery showing 5 and you can swipe or click the button to navigate.
- Single course has a placeholder with a playbutton which will be replaced with MUX player down the line.
- Added a dummy search in the navbar.
- This is built on https://github.com/strapi/internal-lms/pull/9 so if we are merging please merge this first as it's built from this commit we can then merge 
- Courses page has a gallery with filters to the right according to the wireframes
- Currently no state or auth, so a single course just pulls random data from a faker file.
![image](https://github.com/strapi/internal-lms/assets/977232/73b25696-789c-4198-931b-49be4f1d74ce)
![image](https://github.com/strapi/internal-lms/assets/977232/698db6f6-997a-4647-a917-861edf52a787)

![image](https://github.com/strapi/internal-lms/assets/977232/2d4bf95f-b7ca-4e85-9cb4-1b79841ebe15)
